### PR TITLE
Revert "Removed unused variable on logcore.py. "

### DIFF
--- a/typelog/logcore.py
+++ b/typelog/logcore.py
@@ -41,6 +41,9 @@ class StructuredMessage:
         return {"message": self._message, **self._kwargs}
 
 
+sm = StructuredMessage
+
+
 class Typelog:
     def __init__(self, name: str, turn_json: Optional[bool]):
         """


### PR DESCRIPTION
Reverts darklab8/py-typelog#1

Actually no, we should not delete it because... some app already uses this alias as a shortcut to this and i don't wish to break it.